### PR TITLE
Update unico-webframe to v3.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "rxjs": "^7.8.1",
     "tslib": "^2.5.0",
     "zone.js": "~0.15.0",
-    "unico-webframe": "3.20.10"
+    "unico-webframe": "3.21.0"
   },
   "devDependencies": {
     "@angular/build": "^19.2.0",


### PR DESCRIPTION

    Automatic update of `unico-webframe` to version **3.21.0** 📅 Release date: **09/09/2025** 🔗 [Official Release Notes](https://devcenter.unico.io/idcloud/integracao/sdk/integracao-sdks/sdk-web/release-notes)
    