### PR TITLE
Update unico-webframe to v3.23.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "rxjs": "^7.8.1",
     "tslib": "^2.5.0",
     "zone.js": "~0.15.0",
-    "unico-webframe": "3.23.3"
+    "unico-webframe": "3.23.6"
   },
   "devDependencies": {
     "@angular/build": "^19.2.0",


### PR DESCRIPTION

    Automatic update of `unico-webframe` to version **3.23.6** 📅 Release date: **30/03/2026** 🔗 [Official Release Notes](https://devcenter.unico.io/unico-idcloud/by-client-integration/pt/sdk/sdks-disponiveis/sdk-web/release-notes)

    📝 Release notes:
    - Melhorias internas de produto, ajustes e otimizações de segurança.
    